### PR TITLE
RHCEPHQE-15899: [compute] Add support for creating test environment on OpenStack

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,6 +5,10 @@ roles_path = ./roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/role
 filter_plugins = ./plugins/filter:~/plugins/filter:/usr/share/ansible/plugins/filter
 log_path = ~/ansible.log
 
+# Override ssh options
+host_key_checking = False
+timeout = 60
+
 # We may consider ansible.builtin.junit
 callbacks_enabled = ansible.posix.profile_tasks,yaml
 stdout_callback = yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ansible
 ansible-lint
 black
 molecule
+openstacksdk

--- a/roles/ceph/tasks/bootstrap.yaml
+++ b/roles/ceph/tasks/bootstrap.yaml
@@ -67,5 +67,5 @@
       set -euxo pipefail
       cephadm registry-login {{ _args }}
       touch {{ neerali_ceph_log_dir }}/{{ item.registry }}.success
-  creates: "{{ neerali_ceph_log_dir }}/{{ item.registry }}.success"
+    creates: "{{ neerali_ceph_log_dir }}/{{ item.registry }}.success"
   loop: "{{ neerali_prepare_sys_dtrs }}"

--- a/roles/ceph/tasks/osd.yaml
+++ b/roles/ceph/tasks/osd.yaml
@@ -61,7 +61,7 @@
       ansible.builtin.shell:
         cmd: |
           set -euxo pipefail
-          ceph orch apply {{ neerali_ceph_config[neerali_ceph_cluster_name]['osd']['options'] }}
+          ceph orch apply osd {{ neerali_ceph_config[neerali_ceph_cluster_name]['osd']['options'] }}
           touch {{ neerali_ceph_logdir }}/osd.success
         creates: "{{ neerali_ceph_logdir }}/osd.success"
 

--- a/roles/openstack/README.md
+++ b/roles/openstack/README.md
@@ -1,0 +1,74 @@
+# openstack
+
+This role performs create, update and delete operations on openstack resources like networks, volumes and compute instances.
+
+## Parameters
+
+* `neerali_openstack_auth` (dict): holds openstack cloud authentication information.
+We will get the required params value by downloading clouds.yaml file from openstack.
+Refer [supported](#supported-keys-for-neerali_openstack_auth)
+
+### Supported keys for neerali_openstack_auth
+
+* `auth_type` (str) Auth type for openstack cloud.
+* `auth` (dict) has the below key value paris.
+  * `auth_url` (url) URL for RHOS openstack.
+  * `application_credential_id` (str) User id for openstack.
+  * `application_credential_secret` (str) Secret/password for openstack.
+
+## Examples
+
+This role looks for system information in the below format.
+
+```YAML
+neerali_systems_layout:
+  vms:
+    - name: node-01
+      type: ceph
+      cluster: ceph
+      driver: openstack
+      count: N
+      image: <image_name>
+      flavor: <flavor_name>
+      roles:
+        - _admin
+        - mgr
+        - mon
+      networks:
+        - public
+      volumes:
+        size: M
+        count: N
+    - name: node-02
+      type: ceph
+      cluster: ceph
+      driver: openstack
+      image: <image_name>
+      flavor: <flavor_name>
+      roles:
+        - osd
+      volumes:
+        count: N
+        size: M
+      networks:
+        - public
+        - data
+    - name: node-03
+      type: client
+      driver: openstack
+      roles:
+        - client
+      networks:
+        - public
+  networks:
+    public:
+      name: <network-name>
+      driver: openstack
+    data:
+      name: <network-name>
+      cidr: <value>
+      domain: <value>
+      driver: openstack
+
+neerali_use_openstack: true
+```

--- a/roles/openstack/defaults/main.yaml
+++ b/roles/openstack/defaults/main.yaml
@@ -1,0 +1,33 @@
+---
+# (c) Copyright IBM Corporation
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of
+# "neerali_openstack"
+
+neerali_openstack_api_timeout: 600
+neerali_openstack_basedir: >-
+  {{
+    neerali_basedir | default(ansible_user_dir ~ '/neerali-data')
+  }}
+neerali_openstack_artifactdir: >-
+  {{
+    neerali_openstack_basedir ~ '/artifacts/openstack'
+  }}
+neerali_openstack_logdir: >-
+  {{
+    neerali_openstack_basedir ~ '/logs/openstack'
+  }}

--- a/roles/openstack/meta/main.yaml
+++ b/roles/openstack/meta/main.yaml
@@ -1,0 +1,28 @@
+---
+# (c) Copyright IBM Corporation
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+galaxy_info:
+  author: neerali
+  description: neerali role -- openstack
+  company: IBM Corporation
+  license: Apache-2.0
+  min_ansible_version: 2.17
+  namespace: neerali
+  galaxy_tags:
+    - neerali
+    - test
+
+dependencies: []

--- a/roles/openstack/molecule/default/cleanup.yml
+++ b/roles/openstack/molecule/default/cleanup.yml
@@ -14,24 +14,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-# Purpose: The playbook executes tasks related to deploy and configure the
-# system under test.
+# Calls cleanup as part of molecule-cleanup
 
 
-- name: Provision or reimage the systems
-  hosts: "{{ neerali_target_host | default('localhost') }}"
+- name: Cleanup stage for role openstack
+  hosts: all
+  gather_facts: false
 
   tasks:
-    - name: Reimage systems using teuthology
-      when:
-        - neerali_use_teuthology is defined
-        - neerali_use_teuthology | bool
-      ansible.builtin.include_role:
-        name: teuthology
-
-    - name: Provision systems on openstack
-      when:
-        - neerali_use_openstack is defined
-        - neerali_use_openstack | bool
+    - name: Executing cleanup tasks from - openstack
       ansible.builtin.include_role:
         name: openstack
+        tasks_from: cleanup.yaml

--- a/roles/openstack/molecule/default/converge.yml
+++ b/roles/openstack/molecule/default/converge.yml
@@ -1,0 +1,42 @@
+---
+# (c) Copyright IBM Corporation
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Entry point to role
+
+- name: Converge
+  hosts: all
+
+  roles:
+    - role: "openstack"
+
+  tasks:
+    - name: Test the workspace
+      block:
+        - name: Gather the workspace details
+          ansible.builtin.stat:
+            path: "{{ item }}"
+          register: _wrkspace_stat
+          loop:
+            - "{{ neerali_openstack_artifactdir }}"
+            - "{{ neerali_openstack_logdir }}"
+
+        - name: Verify the workspace exists
+          ansible.builtin.assert:
+            that:
+              - item.stat.exists
+          loop: "{{ _wrkspace_stat.results }}"
+          loop_control:
+            label: "{{ item.stat.path }}"

--- a/roles/openstack/molecule/default/molecule.yml
+++ b/roles/openstack/molecule/default/molecule.yml
@@ -1,0 +1,77 @@
+---
+# (c) Copyright IBM Corporation
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Central configuration entry point for molecule per scenario.
+
+log: true
+prerun: false
+
+provisioner:
+  name: ansible
+  log: true
+  inventory:
+    host_vars:
+      instance:
+        neerali_basedir: /tmp/neerali-data
+        ansible_user_dir: /tmp
+        neerali_systems_layout:
+          vms:
+            - name: node-01
+              type: ceph
+              cluster: ceph
+              driver: openstack
+              count: 2
+              image: RHEL-9.5.0-x86_64
+              flavor: test_flavor
+              roles:
+                - _admin
+                - mgr
+              volumes:
+                size: 2
+                count: 2
+              networks:
+                - test_net1
+              cloud_init: |
+                #cloud-config
+                ssh_pwauth: true
+                disable_root: false
+
+                groups:
+                  - cephuser
+
+                users:
+                  - name: cephuser
+                    primary-group: cephuser
+                    sudo: ALL=(ALL) NOPASSWD:ALL
+                    shell: /bin/bash
+
+                chpasswd:
+                  list: |
+                    root:passwd
+                    cephuser:pass123
+                  expire: false
+
+          networks:
+            public:
+              name: public-net
+              driver: openstack
+            data:
+              name: private-net
+              cidr: x.x.x.x/y
+              domain: testdomain.com
+              driver: openstack
+
+        neerali_use_openstack: true

--- a/roles/openstack/molecule/default/prepare.yml
+++ b/roles/openstack/molecule/default/prepare.yml
@@ -14,24 +14,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-# Purpose: The playbook executes tasks related to deploy and configure the
-# system under test.
 
-
-- name: Provision or reimage the systems
-  hosts: "{{ neerali_target_host | default('localhost') }}"
+- name: Prepare
+  hosts: all
 
   tasks:
-    - name: Reimage systems using teuthology
-      when:
-        - neerali_use_teuthology is defined
-        - neerali_use_teuthology | bool
-      ansible.builtin.include_role:
-        name: teuthology
-
-    - name: Provision systems on openstack
-      when:
-        - neerali_use_openstack is defined
-        - neerali_use_openstack | bool
-      ansible.builtin.include_role:
-        name: openstack
+    - name: Ensure basedir exists
+      ansible.builtin.file:
+        path: "{{ neerali_basedir }}"
+        state: directory
+        mode: "0755"
+        owner: "{{ ansible_user_id }}"
+        group: "{{ ansible_user_gid }}"

--- a/roles/openstack/tasks/cleanup.yaml
+++ b/roles/openstack/tasks/cleanup.yaml
@@ -1,0 +1,64 @@
+---
+# (c) Copyright IBM Corporation
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Check if the neerali openstack systems provisoned file exists
+  ansible.builtin.stat:
+    path: "{{ neerali_openstack_artifactdir ~ '/neerali_openstack_provisioned_systems.yaml' }}"
+  register: neerali_systems_provisioned_stat
+
+- name: Load the yaml content if the file exists
+  ansible.builtin.include_vars:
+    file: "{{ neerali_openstack_artifactdir ~ '/neerali_openstack_provisioned_systems.yaml' }}"
+  when: neerali_systems_provisioned_stat.stat.exists
+
+- name: Delete openstack networks
+  vars:
+    neerali_network_action: delete
+    neerali_network_payload: "{{ neerali_systems_layout.networks }}"
+  ansible.builtin.include_tasks: network.yaml
+  when: neerali_systems_layout.networks is defined
+
+- name: Delete servers
+  vars:
+    neerali_server_action: delete
+  ansible.builtin.include_tasks: server.yaml
+  when: neerali_openstack_systems_provisioned is defined
+
+- name: Delete volumes
+  vars:
+    neerali_volume_action: delete
+  ansible.builtin.include_tasks: volume.yaml
+  loop: "{{ neerali_openstack_systems_provisioned }}"
+  loop_control:
+    loop_var: compute_node
+  when: neerali_openstack_systems_provisioned is defined
+
+- name: Delete a neerali openstack systems provisioned file
+  ansible.builtin.file:
+    path: "{{ neerali_openstack_artifactdir ~ '/neerali_openstack_provisioned_systems.yaml' }}"
+    state: absent
+  when: neerali_systems_provisioned_stat.stat.exists
+
+- name: Ensure workspace is cleaned
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ neerali_openstack_artifactdir }}"
+    - "{{ neerali_openstack_logdir }}"
+  loop_control:
+    label: "{{ item }}"

--- a/roles/openstack/tasks/main.yaml
+++ b/roles/openstack/tasks/main.yaml
@@ -1,0 +1,92 @@
+---
+# (c) Copyright IBM Corporation
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Ensure workspace exists
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0755"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_gid }}"
+  loop:
+    - "{{ neerali_openstack_basedir }}"
+    - "{{ neerali_openstack_artifactdir }}"
+    - "{{ neerali_openstack_logdir }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: Create networks
+  ansible.builtin.include_tasks: network.yaml
+  vars:
+    neerali_network_action: create
+    neerali_network_payload: "{{ neerali_systems_layout.networks }}"
+  when: neerali_systems_layout.networks is defined
+
+- name: Create servers
+  vars:
+    neerali_server_action: create
+  ansible.builtin.include_tasks: server.yaml
+  loop: "{{ neerali_systems_layout.vms }}"
+  loop_control:
+    loop_var: neerali_server_config
+  when:
+    - neerali_systems_layout.vms is defined
+    - neerali_server_config.driver == "openstack"
+
+- name: Create neerali systems provisioned map
+  ansible.builtin.set_fact:
+    neerali_openstack_systems_data: { 'neerali_openstack_systems_provisioned': "{{ neerali_openstack_systems_provisioned }}" }
+  when:
+    - neerali_systems_layout.vms is defined
+    - neerali_openstack_systems_provisioned is defined
+
+- name: Store systems provisioned data to artifacts
+  ansible.builtin.copy:
+    dest: >-
+      {{
+        (neerali_openstack_artifactdir, 'neerali_openstack_provisioned_systems.yaml') |
+        ansible.builtin.path_join
+      }}
+    content: "{{ neerali_openstack_systems_data | to_nice_yaml }}"
+  when:
+    - neerali_systems_layout.vms is defined
+    - neerali_openstack_systems_data is defined
+
+- name: Add the provisoned systems to inventory
+  ansible.builtin.add_host:
+    name: "{{ item.name }}"
+    groups: "{{ item.roles + ['nodes'] }}"
+    ansible_host: "{{ item.ansible_host }}"
+    ansible_user: "{{ item.ansible_ssh_user }}"
+    neerali_ceph_cluster_name: "{{ item.cluster | default('ceph') }}"
+  loop: "{{ neerali_openstack_systems_provisioned }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: neerali_openstack_systems_provisioned is defined
+
+- name: Add the openstack systems to the neerali provisioned list
+  ansible.builtin.set_fact:
+    neerali_systems_provisioned: >-
+      {{
+        (neerali_systems_provisioned | default([])) + neerali_openstack_systems_provisioned
+      }}
+  when: neerali_openstack_systems_provisioned is defined
+
+- name: Wait for compute nodes to be reachable
+  ansible.builtin.wait_for_connection:
+  delegate_to: "{{ item }}"
+  loop: "{{ groups['nodes'] }}"

--- a/roles/openstack/tasks/network.yaml
+++ b/roles/openstack/tasks/network.yaml
@@ -1,0 +1,29 @@
+---
+# (c) Copyright IBM Corporation
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Role Info
+  ansible.builtin.debug:
+    msg: "TODO: Ansible role exclusively for creating and deleting networks {{ neerali_network_action }}"
+
+- name: Create openstack networks
+  ansible.builtin.debug:
+    msg: "Creating networks for payload {{ neerali_network_payload | to_nice_json }}"
+  when: neerali_network_action == "create"
+
+- name: Delete private/data networks
+  ansible.builtin.debug:
+    msg: "Deleting networks for payload {{ neerali_network_payload.data.name }}"
+  when: neerali_network_action == "delete"

--- a/roles/openstack/tasks/server.yaml
+++ b/roles/openstack/tasks/server.yaml
@@ -1,0 +1,166 @@
+---
+# (c) Copyright IBM Corporation
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Extract OS info from image name of server {{ neerali_server_config.name }}
+  ansible.builtin.set_fact:
+    _neerali_openstack_os_data: >-
+      {{
+        {
+          'type': neerali_server_config.image.split('-')[0] | lower,
+          'version': neerali_server_config.image.split('-')[1].split('.')[0:2] | join('.')
+        }
+      }}
+  when: neerali_server_action | default('') == 'create'
+
+- name: Extract cloud-init yaml for server {{ neerali_server_config.name }}
+  ansible.builtin.set_fact:
+    _neerali_openstack_cloud_init: "{{ neerali_server_config.cloud_init | from_yaml }}"
+  when: neerali_server_action | default('') == 'create'
+
+- name: Reset network nics payload for each server
+  ansible.builtin.set_fact:
+    _neerali_openstack_network_nics: []
+  when: neerali_server_action | default('') == 'create'
+
+- name: Generate nics payload for server {{ neerali_server_config.name }}
+  ansible.builtin.set_fact:
+    _neerali_openstack_network_nics: >-
+      {{
+        _neerali_openstack_network_nics +
+        [
+          {
+            'net-name' : network_name
+          }
+        ]
+      }}
+  loop: "{{ neerali_server_config.networks }}"
+  loop_control:
+    loop_var: network_name
+  when:
+    - neerali_server_action | default('') == 'create'
+    - neerali_server_config.networks is defined
+
+- name: Set default server count as 1 if count is not defined
+  ansible.builtin.set_fact:
+    _neerali_server_count: "{{ neerali_server_config.count | default(1) }}"
+  when: neerali_server_action | default('') == 'create'
+
+- name: Reset instance names to volumes map for each node
+  ansible.builtin.set_fact:
+    neerali_openstack_server_volume_map: {}
+  when: neerali_server_action | default('') == 'create'
+
+- name: Generate dynamic prefix name for server node
+  ansible.builtin.set_fact:
+    _neerali_openstack_server_prefix: "{{ range(1000,9999) | random }}"
+
+- name: Create instance names to volumes map for server {{ neerali_server_config.name }}
+  ansible.builtin.set_fact:
+    neerali_openstack_server_volume_map: >-
+      {{
+        neerali_openstack_server_volume_map | combine(
+          {
+            (
+              '%s-%s-%s-%02d'|format(
+                neerali_server_config.cluster,
+                _neerali_openstack_server_prefix,
+                neerali_server_config.name,
+                item
+              )
+            ): []
+          }
+        )
+      }}
+  loop: "{{ range(1, _neerali_server_count|int + 1) }}"
+  when: neerali_server_action | default('') == 'create'
+
+- name: Create volumes
+  vars:
+    neerali_volume_action: create
+    neerali_volume_data: "{{ neerali_server_config.volumes }}"
+  ansible.builtin.include_tasks: volume.yaml
+  when:
+    - neerali_server_action | default('') == 'create'
+    - neerali_server_config.volumes is defined
+
+- name: Create compute instances for {{ neerali_server_config.name }}
+  openstack.cloud.server:
+    cloud: "{{ neerali_openstack_auth }}"
+    state: present
+    name: "{{ item.key }}"
+    image: "{{ neerali_server_config.image }}"
+    flavor: "{{ neerali_server_config.flavor }}"
+    nics: "{{ _neerali_openstack_network_nics }}"
+    volumes: "{{ item.value }}"
+    terminate_volume: "{{ true | bool }}"
+    timeout: "{{ neerali_openstack_api_timeout }}"
+    userdata: "{{ neerali_server_config.cloud_init }}"
+  async: "{{ neerali_openstack_api_timeout }}"
+  poll: 0
+  register: _neerali_openstack_async_servers
+  loop: "{{ neerali_openstack_server_volume_map | dict2items }}"
+  when: neerali_server_action | default('') == 'create'
+
+- name: Wait for all computes to be created for {{ neerali_server_config.name }}
+  ansible.builtin.async_status:
+    jid: "{{ item.ansible_job_id }}"
+  register: _neerali_openstack_systems
+  until: _neerali_openstack_systems.finished
+  retries: "{{ (neerali_openstack_api_timeout / 10) | int }}"
+  delay: 10
+  loop: "{{ _neerali_openstack_async_servers.results }}"
+  loop_control:
+    label: "{{ item.ansible_job_id }}"
+  when:
+    - neerali_server_action | default('') == 'create'
+    - _neerali_openstack_async_servers is defined
+
+- name: Add systems to openstack provisioned list
+  ansible.builtin.set_fact:
+    neerali_openstack_systems_provisioned: >-
+      {{
+        neerali_openstack_systems_provisioned | default([]) +
+        [
+          {
+            'name': item.server.name,
+            'ansible_host': item | json_query('server.addresses.' + neerali_server_config.networks.0 + '[0].addr'),
+            'ansible_ssh_user': _neerali_openstack_cloud_init.users.0.name,
+            'type': neerali_server_config.type,
+            'cluster': neerali_server_config.cluster,
+            'os': _neerali_openstack_os_data,
+            'roles': neerali_server_config.roles,
+            'volumes': neerali_openstack_server_volume_map[item.server.name],
+            'driver': neerali_server_config.driver
+          }
+        ]
+      }}
+  loop: "{{ _neerali_openstack_systems.results }}"
+  loop_control:
+    label: "{{ item.server.name }}"
+  when:
+    - neerali_server_action | default('') == 'create'
+    - _neerali_openstack_systems is defined
+
+- name: Delete compute instances
+  openstack.cloud.server:
+    cloud: "{{ neerali_openstack_auth }}"
+    name: "{{ item.name }}"
+    state: absent
+  loop: "{{ neerali_openstack_systems_provisioned }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - neerali_server_action | default('') == 'delete'

--- a/roles/openstack/tasks/volume.yaml
+++ b/roles/openstack/tasks/volume.yaml
@@ -1,0 +1,121 @@
+---
+# (c) Copyright IBM Corporation
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Set default volume count as 1 if volume count per each server is not defined
+  ansible.builtin.set_fact:
+    _neerali_openstack_volumes_per_server: "{{ neerali_volume_data.count | default(1) }}"
+  when:
+    - neerali_volume_action | default('') == 'create'
+
+- name: Allocate volume names to each server node
+  ansible.builtin.set_fact:
+    neerali_openstack_server_volume_map: >-
+      {{
+        neerali_openstack_server_volume_map | combine(
+          {
+            item.0: neerali_openstack_server_volume_map[ item.0 ] +
+            [
+              '%s-vol-%02d'|format(
+                item.0,
+                item.1
+              )
+            ]
+          }
+        )
+      }}
+  loop: "{{
+            neerali_openstack_server_volume_map |
+            product(
+              range(1, _neerali_openstack_volumes_per_server|int + 1)
+            )
+        }}"
+  when:
+    - neerali_volume_action | default('') == 'create'
+    - neerali_openstack_server_volume_map is defined
+
+- name: Reset volumes names list for each node
+  ansible.builtin.set_fact:
+    _neerali_openstack_volume_names: []
+  when:
+    - neerali_volume_action | default('') == 'create'
+
+- name: Fetch the volume names for all server nodes
+  ansible.builtin.set_fact:
+    _neerali_openstack_volume_names: "{{ _neerali_openstack_volume_names + item.value }}"
+  loop: "{{ neerali_openstack_server_volume_map | dict2items }}"
+  when:
+    - neerali_volume_action | default('') == 'create'
+
+- name: Create volumes for all instances of server
+  openstack.cloud.volume:
+    cloud: "{{ neerali_openstack_auth }}"
+    state: present
+    name: "{{ item }}"
+    description: "{{ item }}"
+    size: "{{ neerali_volume_data.size | int }}"
+  async: "{{ neerali_openstack_api_timeout }}"
+  poll: 0
+  register: _neerali_openstack_async_volumes
+  loop: "{{ _neerali_openstack_volume_names }}"
+  when:
+    - neerali_volume_action | default('') == 'create'
+    - neerali_volume_data.size is defined
+    - _neerali_openstack_volume_names is defined
+
+- name: Wait for all volumes to be created
+  ansible.builtin.async_status:
+    jid: "{{ item.ansible_job_id }}"
+  register: _neerali_openstack_volumes
+  until: _neerali_openstack_volumes.finished
+  retries: "{{ (neerali_openstack_api_timeout / 10) | int}}"
+  delay: 10
+  loop: "{{ _neerali_openstack_async_volumes.results }}"
+  loop_control:
+    label: "{{ item.ansible_job_id }}"
+  when:
+    - neerali_volume_action | default('') == 'create'
+    - _neerali_openstack_async_volumes is defined
+
+- name: Check if volumes exist
+  openstack.cloud.volume_info:
+    cloud: "{{ neerali_openstack_auth }}"
+    name: "{{ item }}"
+  loop: "{{ compute_node.volumes }}"
+  register: volume_info
+  when:
+    - neerali_volume_action | default('') == 'delete'
+
+- name: Reset combined volumes list for each compute node
+  ansible.builtin.set_fact:
+    _neerali_combined_volumes: []
+  when:
+    - neerali_volume_action | default('') == 'delete'
+
+- name: Combine all volumes of each compute node
+  ansible.builtin.set_fact:
+    _neerali_combined_volumes: "{{ _neerali_combined_volumes + (item | json_query('volumes')) }}"
+  loop: "{{ volume_info.results }}"
+  when:
+    - neerali_volume_action | default('') == 'delete'
+
+- name: Delete OpenStack Volume of compute node
+  openstack.cloud.volume:
+    cloud: "{{ neerali_openstack_auth }}"
+    name: "{{ item }}"
+    state: absent
+  loop: "{{ _neerali_combined_volumes | map(attribute='name') | list }}"
+  when:
+    - neerali_volume_action | default('') == 'delete'

--- a/roles/openstack/vars/main.yaml
+++ b/roles/openstack/vars/main.yaml
@@ -1,0 +1,19 @@
+---
+# (c) Copyright IBM Corporation
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Variables that should not be modified during the course of execution are
+# specified here. They should have a prefix of
+# "neerali_openstack"

--- a/roles/prepare_sys/tasks/host.yaml
+++ b/roles/prepare_sys/tasks/host.yaml
@@ -22,7 +22,9 @@
     neerali_ceph_public_network: >-
       {{
         neerali_ceph_config[neerali_ceph_cluster_name]['public_network'] |
-        default(ansible_default_ipv4.network)
+        default(
+          ansible_default_ipv4.network ~ '/' ~ ansible_default_ipv4.prefix
+        )
       }}
 
 - name: Gather the public network block


### PR DESCRIPTION
* In this PR, I have added support to create and cleanup compute nodes with volumes on openstack environment.
* Added a role for openstack deployments based on `neerali_systems_layout`.
* Creates multiple volumes for a single instances asynchronously.
* Creates multiple compute instances asynchronously with volumes attached to them.
* Added molecule unit tests for openstack role.
* Updated README documentation about openstack role.
* Ran end to end ceph installation flow on openstack deployed nodes